### PR TITLE
Update rake dependency to 12.3.3

### DIFF
--- a/_site/jekyll-cayman-theme.gemspec
+++ b/_site/jekyll-cayman-theme.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "jekyll", "~> 3.2"
   spec.add_development_dependency "bundler", "~> 2.1.4"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.3.3"
 end

--- a/jekyll-cayman-theme.gemspec
+++ b/jekyll-cayman-theme.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "jekyll", "~> 3.2"
   spec.add_development_dependency "bundler", "~> 2.1.4"
-  spec.add_development_dependency "rake", "~> 12.3"
+  spec.add_development_dependency "rake", ">= 12.3.3"
 end

--- a/jekyll-cayman-theme.gemspec
+++ b/jekyll-cayman-theme.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "jekyll", "~> 3.2"
   spec.add_development_dependency "bundler", "~> 2.1.4"
-  spec.add_development_dependency "rake", ">= 12.3.3"
+  spec.add_development_dependency "rake", "~> 12.3.3"
 end


### PR DESCRIPTION
Update rake dependency to 12.3.3 to fix [CVE-2020-8130](https://github.com/advisories/GHSA-jppv-gw3r-w3q8)

>  Vulnerable versions: <= 12.3.2
>  Patched version: 12.3.3
>  
>  There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins   with the pipe character |.